### PR TITLE
Express.js intialisation

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,11 @@
+// This file separates express.js declarations and routes from the server.js file in order to allow testing to operate
+// Otherwise it causes jest to hang indefinitely
+const express = require('express');
+
+const app = express();
+
+// Bind public page routes
+app.use(express.static('public'));
+
+
+module.exports = app;

--- a/app.js
+++ b/app.js
@@ -1,11 +1,16 @@
 // This file separates express.js declarations and routes from the server.js file in order to allow testing to operate
 // Otherwise it causes jest to hang indefinitely
 const express = require('express');
+const path = require('path');
 
 const app = express();
 
-// Bind public page routes
-app.use(express.static('public'));
+// Bind public page route
+app.use(express.static(path.join(__dirname, 'public')));
 
+// We'll want to move this in future to the router
+app.get('/notes', (req, res) => {
+    res.status(200).sendFile(path.join(__dirname, 'public/notes.html'));
+});
 
 module.exports = app;

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "devDependencies": {
     "jest": "^29.7.0",
     "supertest": "^6.3.4"
+  },
+  "jest": {
+    "verbose": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "jest"
+    "test": "jest",
+    "check-handles": "jest --detectOpenHandles"
   },
   "author": "Nat Poulson",
   "license": "ISC",

--- a/server.js
+++ b/server.js
@@ -3,4 +3,6 @@ const app = require('./app');
 
 const PORT = process.env.PORT || 3001;
 
-app.listen(PORT);
+app.listen(PORT, () => {
+    console.log(`Now listening on http://localhost:${PORT}`);
+});

--- a/server.js
+++ b/server.js
@@ -1,12 +1,6 @@
 // TODO: Implement express.js and connect middleware
-const express = require('express');
-
-const app = express();
+const app = require('./app');
 
 const PORT = process.env.PORT || 3001;
 
-app.use(express.static('public'));
-
-app.listen(PORT, () => {
-    console.log(`Now listening on http://localhost:${PORT}`);
-});
+app.listen(PORT);

--- a/server.js
+++ b/server.js
@@ -1,1 +1,12 @@
 // TODO: Implement express.js and connect middleware
+const express = require('express');
+
+const app = express();
+
+const PORT = process.env.PORT || 3001;
+
+app.use(express.static('public'));
+
+app.listen(PORT, () => {
+    console.log(`Now listening on http://localhost:${PORT}`);
+});

--- a/tests/express.test.js
+++ b/tests/express.test.js
@@ -1,17 +1,17 @@
 const fs = require('fs/promises');
 const request = require('supertest');
-const app = require('../server');
+const app = require('../app');
 
 describe('Express.js', () => {
     describe('Public Routes', () => {
         it('root (/) returns public/index.html', async () => {
-            const comparison = await fs.readFile('../public/index.html', {encoding: 'utf-8'}, err => undefined);
+            const comparison = await fs.readFile('./public/index.html', {encoding: 'utf-8'}, err => undefined);
             const res = await request(app).get('/');
             expect(res.body).toEqual(comparison);
         });
-        it('pages (/pages) returns public/pages.html', async () => {
-            const comparison = await fs.readFile('../public/pages.html', {encoding: 'utf-8'}, err => undefined);
-            const res = await request(app).get('/pages');
+        it('notes (/notes) returns public/notes.html', async () => {
+            const comparison = await fs.readFile('./public/notes.html', {encoding: 'utf-8'}, err => undefined);
+            const res = await request(app).get('/notes');
             expect(res.body).toEqual(comparison);
         });
     });

--- a/tests/express.test.js
+++ b/tests/express.test.js
@@ -7,12 +7,12 @@ describe('Express.js', () => {
         it('root (/) returns public/index.html', async () => {
             const comparison = await fs.readFile('./public/index.html', {encoding: 'utf-8'}, err => undefined);
             const res = await request(app).get('/');
-            expect(res.body).toEqual(comparison);
+            expect(res.text).toEqual(comparison);
         });
         it('notes (/notes) returns public/notes.html', async () => {
             const comparison = await fs.readFile('./public/notes.html', {encoding: 'utf-8'}, err => undefined);
             const res = await request(app).get('/notes');
-            expect(res.body).toEqual(comparison);
+            expect(res.text).toEqual(comparison);
         });
     });
     describe('API Routes', () => {

--- a/tests/notes.test.js
+++ b/tests/notes.test.js
@@ -1,9 +1,9 @@
 // Declare required modules
 const fs = require('fs/promises');
 const request = require('supertest');
-const app = require('../server');
+const app = require('../app');
 
-const dataSet = async () => JSON.parse(await fs.readFile('../db/test.json', {encoding: 'utf-8'}));
+const dataSet = async () => JSON.parse(await fs.readFile('./db/test.json', {encoding: 'utf-8'}));
 
 describe('Notes API', () => {
     describe('GET', () => {


### PR DESCRIPTION
This PR sets up the Express.js solution and implements a static route to the front page, and a route to the notes page.

Additionally, there's a structural separation between the app and the 'server' file to enable testing of express.js without causing Jest to hang from the listen operation.